### PR TITLE
fix bug in Module::Runtime usage

### DIFF
--- a/lib/Crypt/XkcdPassword.pm
+++ b/lib/Crypt/XkcdPassword.pm
@@ -12,7 +12,7 @@ BEGIN {
 
 use match::simple            qw( match );
 use Carp                     qw( carp croak );
-use Module::Runtime          qw( require_module );
+use Module::Runtime          qw( use_module );
 use Types::Standard 1.000000 qw( CodeRef Str ConsumerOf ArrayRef );
 
 use Moo 1.006000;
@@ -28,8 +28,8 @@ my $wordrole = 'Crypt::XkcdPassword::Words';
 has words => (
 	is      => "rw",
 	isa     => ConsumerOf->of($wordrole)->plus_coercions(
-		Str,      sub { require_module("$wordrole\::$_")->new },
-		ArrayRef, sub { my ($c, @a) = @$_; require_module("$wordrole\::$c")->new(@a) },
+		Str,      sub { use_module("$wordrole\::$_")->new },
+		ArrayRef, sub { my ($c, @a) = @$_; use_module("$wordrole\::$c")->new(@a) },
 	),
 	coerce  => 1,
 	default => sub { "EN" },


### PR DESCRIPTION
Module::Runtime->require_module returns 1 on success if module is already loaded, which breaks in this usecase:

matt@mercury:~$ perl -MCrypt::XkcdPassword -Mfeature="say" -e 'say Crypt::XkcdPassword->make_password for 1..2'
k amy jennings taken
coercion for "words" failed: Can't locate object method "new" via package "1" (perhaps you forgot to load "1"?) at /home/matt/perl5/lib/perl5/Crypt/XkcdPassword.pm line 31, <DATA> line 9998.

Module::Runtime->use_module always returns the loaded module name for expected constructor usage.
