### PR TITLE
failing test for https://rt.cpan.org/Ticket/Display.html?id=103287

### DIFF
--- a/t/05-multi_calls.t
+++ b/t/05-multi_calls.t
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl;
+use warnings;
+use strict;
+use Crypt::XkcdPassword;
+use Test::Most;
+my $xk = Crypt::XkcdPassword->new;
+lives_ok { $xk->make_password };
+lives_ok { $xk->make_password };
+
+lives_ok { Crypt::XkcdPassword->make_password()};
+lives_ok { Crypt::XkcdPassword->make_password()};
+
+done_testing;


### PR DESCRIPTION
Crypt::XkdcPassword is useful for reasonably random human readable text fixtures.  Came across this bug while working up some test data.  
